### PR TITLE
SetPowerStateREDFISH.py: Improved readability and minor functionality

### DIFF
--- a/Redfish Python/SetPowerStateREDFISH.py
+++ b/Redfish Python/SetPowerStateREDFISH.py
@@ -3,9 +3,9 @@
 #
 #
 # _author_ = Texas Roemer <Texas_Roemer@Dell.com>
-# _version_ = 3.0
+# _version_ = 4.0
 #
-# Copyright (c) 2017, Dell, Inc.
+# Copyright (c) 2021, Dell, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -16,59 +16,77 @@
 #
 
 
-import requests, json, sys, re, time, warnings, argparse
+import argparse
+import json
+import requests
+import sys
+import warnings
 
 warnings.filterwarnings("ignore")
 
-parser=argparse.ArgumentParser(description="Python script using Redfish API to either get current server power state and possible power state values or execute server power state change")
-parser.add_argument('-ip',help='iDRAC IP address', required=True)
+parser = argparse.ArgumentParser(
+    description="Python script using Redfish API to either get current server power state and possible power state "
+                "values or execute server power state change")
+parser.add_argument('-ip', help='iDRAC IP address', required=True)
 parser.add_argument('-u', help='iDRAC username', required=True)
 parser.add_argument('-p', help='iDRAC password', required=True)
-parser.add_argument('script_examples',action="store_true",help='SetPowerStateREDFISH.py -ip 192.168.0.120 -u root -p calvin -g y, this example will return the current power state of the server and supported values for changing the server power state. SetPowerStateREDFISH.py -ip 100.65.205.66 -u root -p calvin -r On, this example will power on the server') 
-parser.add_argument('-g', help='Get current power state of the server and possible values for ComputerSystem.Reset action, pass in \"y\" ', required=False)
-parser.add_argument('-r', help='Pass in the computer system reset type you want to perform. To get supported possible values, execute the script with -g argument', required=False)
+mutex_group = parser.add_mutually_exclusive_group(required=True)
+mutex_group.add_argument('--script-examples', action="store_true",
+                         help='Prints a set of examples for this script.')
+mutex_group.add_argument('-g',
+                         help='Get current power state of the server and possible values for ComputerSystem.Reset.',
+                         action='store_true')
+mutex_group.add_argument('-r',
+                         help='Pass in the computer system reset type you want to perform. To get supported possible '
+                              'values, execute the script with -g argument')
 
-args=vars(parser.parse_args())
+args = vars(parser.parse_args())
 
-idrac_ip=args["ip"]
-idrac_username=args["u"]
-idrac_password=args["p"]
+idrac_ip = args["ip"]
+idrac_username = args["u"]
+idrac_password = args["p"]
 
 
 def get_current_power_state():
-    response = requests.get('https://%s/redfish/v1/Systems/System.Embedded.1/' % idrac_ip,verify=False,auth=(idrac_username, idrac_password))
+    response = requests.get('https://%s/redfish/v1/Systems/System.Embedded.1/' % idrac_ip, verify=False,
+                            auth=(idrac_username, idrac_password))
     data = response.json()
     print("\n- WARNING, Current server power state is: %s\n" % data[u'PowerState'])
     print("- Supported values for server power control are:\n")
     for i in data[u'Actions'][u'#ComputerSystem.Reset'][u'ResetType@Redfish.AllowableValues']:
         print(i)
 
+
 def set_power_state():
-    response = requests.get('https://%s/redfish/v1/Systems/System.Embedded.1/' % idrac_ip,verify=False,auth=(idrac_username, idrac_password))
-    data = response.json()
+    requests.get('https://%s/redfish/v1/Systems/System.Embedded.1/' % idrac_ip, verify=False,
+                 auth=(idrac_username, idrac_password))
     print("\n- WARNING, setting new server power state to: %s" % (args["r"]))
 
     url = 'https://%s/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset' % idrac_ip
     payload = {'ResetType': args["r"]}
     headers = {'content-type': 'application/json'}
-    response = requests.post(url, data=json.dumps(payload), headers=headers, verify=False, auth=(idrac_username,idrac_password))
+    response = requests.post(url, data=json.dumps(payload), headers=headers, verify=False,
+                             auth=(idrac_username, idrac_password))
 
-
-    statusCode = response.status_code
-    if statusCode == 204:
-        print("\n- PASS, status code %s returned, server power state successfully set to \"%s\"\n" % (statusCode, args["r"]))
+    status_code = response.status_code
+    if status_code == 204:
+        print("\n- PASS, status code %s returned, server power state successfully set to \"%s\"\n" % (
+            status_code, args["r"]))
     else:
-        print("\n- FAIL, Command failed, status code %s returned\n" % statusCode)
+        print("\n- FAIL, Command failed, status code %s returned\n" % status_code)
         print(response.json())
         sys.exit()
+
 
 if __name__ == "__main__":
     if args["g"]:
         get_current_power_state()
     elif args["r"]:
         set_power_state()
+    elif args["script_examples"]:
+        print('SetPowerStateREDFISH.py -ip 192.168.0.120 -u root -p calvin -g, this example will '
+              'return the current power state of the server and supported values for changing the '
+              'server power state. SetPowerStateREDFISH.py -ip 100.65.205.66 -u root -p calvin -r On,'
+              ' this example will power on the server')
     else:
         print("- FAIL, incorrect parameter(s) passed in or missing required parameters")
-        
-        
-


### PR DESCRIPTION
- Made script PEP8 and PEP484 compliant
- Updated long lines to wrap after 120 to improve readability
- Updated the script to use a mutually exclusive group for required arguments so that the user must provide one and only one of -g, --script-examples, or -r
- Made the -g argument a switch so that the user does not have to pass in -y. Passing the option is sufficient
- Removed unused imports and unused variables (ex response and data were declared but never used)
- Fixed script-examples so that it was used. In the previous version the option did not do anything other than display in the help menu itself
- Changed script_examples argument to --script-examples to follow standard syntax practices for multi-word python arguments
- Revved version number and updated copyright

Signed-off-by: Grant Curell <grant_curell@dell.com>