### PR TITLE
Correct string interpolation of print() returns

### DIFF
--- a/Redfish Python/CreateDeleteIdracUsersREDFISH.py
+++ b/Redfish Python/CreateDeleteIdracUsersREDFISH.py
@@ -96,14 +96,14 @@ def create_idrac_user_password():
     if statusCode == 200:
         print("\n- PASS, status code %s returned for PATCH command to create iDRAC user \"%s\"" % (statusCode, args["un"]))
     else:
-        print("\n- FAIL, status code %s returned, password was not changed") % statusCode
+        print("\n- FAIL, status code %s returned, password was not changed" % statusCode)
         sys.exit()
 
 def verify_idrac_user_created():
     response = requests.get('https://%s/redfish/v1/Managers/iDRAC.Embedded.1/Accounts/%s' % (idrac_ip, args["id"]),verify=False,auth=(idrac_username, idrac_password))
     statusCode = response.status_code
     if statusCode != 200:
-        print("\n- FAIL, status code %s returned for GET command") % statusCode
+        print("\n- FAIL, status code %s returned for GET command" % statusCode)
         sys.exit()
     else:
         pass
@@ -138,7 +138,7 @@ def delete_idrac_user():
     response = requests.get('https://%s/redfish/v1/Managers/iDRAC.Embedded.1/Accounts/%s' % (idrac_ip, args["d"]),verify=False,auth=(idrac_username, idrac_password))
     statusCode = response.status_code
     if statusCode != 200:
-        print("\n- FAIL, status code %s returned for GET command") % statusCode
+        print("\n- FAIL, status code %s returned for GET command" % statusCode)
         sys.exit()
     else:
         pass
@@ -155,7 +155,7 @@ def get_current_iDRAC_user_information():
         response = requests.get('https://%s/redfish/v1/Managers/iDRAC.Embedded.1/Accounts/%s' % (idrac_ip, args["id"]),verify=False,auth=(idrac_username, idrac_password))
         statusCode = response.status_code
         if statusCode != 200:
-            print("\n- FAIL, status code %s returned for GET command") % statusCode
+            print("\n- FAIL, status code %s returned for GET command" % statusCode)
             sys.exit()
         else:
             pass
@@ -173,7 +173,7 @@ def get_current_iDRAC_user_information():
             response = requests.get('https://%s/redfish/v1/Managers/iDRAC.Embedded.1/Accounts/%s' % (idrac_ip, i),verify=False,auth=(idrac_username, idrac_password))
             statusCode = response.status_code
             if statusCode != 200:
-                print("\n- FAIL, status code %s returned for GET command") % statusCode
+                print("\n- FAIL, status code %s returned for GET command" % statusCode)
                 sys.exit()
             else:
                 pass

--- a/Redfish Python/GetOSNetworkInformationREDFISH.py
+++ b/Redfish Python/GetOSNetworkInformationREDFISH.py
@@ -73,7 +73,7 @@ def get_OS_network_devices():
         for i in valid_network_devices:
             response = requests.get('https://%s/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces/%s' % (idrac_ip, i),verify=False,auth=(idrac_username,idrac_password))
             data = response.json()
-            print("\n- Detailed information for network device %s -\n") % i
+            print("\n- Detailed information for network device %s -\n" % i)
             for ii in data.items():
                 print("%s: %s" % (ii[0], ii[1]))
             
@@ -82,7 +82,7 @@ def get_OS_network_devices():
 def get_individual_network_device_info():
     response = requests.get('https://%s/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces/%s' % (idrac_ip, args["n"]),verify=False,auth=(idrac_username,idrac_password))
     data = response.json()
-    print("\n- Detailed information for network device %s -\n") % args["n"]
+    print("\n- Detailed information for network device %s -\n" % args["n"])
     for ii in data.items():
         print("%s: %s" % (ii[0], ii[1]))
 
@@ -92,7 +92,7 @@ def get_property_value_only():
     count=0
     for i in data.items():
         if i[0] == property_value:
-            print("\n- Property \"%s\" information for network device %s -\n") % (property_value, args["i"])
+            print("\n- Property \"%s\" information for network device %s -\n" % (property_value, args["i"]))
             print("%s: %s" % (i[0], i[1]))
             count+=1
     if count == 0:

--- a/Redfish Python/IdracResetToDefaultsREDFISH.py
+++ b/Redfish Python/IdracResetToDefaultsREDFISH.py
@@ -60,7 +60,7 @@ def reset_idrac_to_default_settings():
         print("\n- PASS, status code %s returned for POST command to reset iDRAC to \"%s\" setting\n" % (statusCode, reset_type))
     else:
         data=response.json()
-        print("\n- FAIL, status code %s returned, error is: \n%s") % (statusCode, data)
+        print("\n- FAIL, status code %s returned, error is: \n%s" % (statusCode, data))
         sys.exit()
     time.sleep(15)
     print("- WARNING, iDRAC will now reset and be back online within a few minutes.")

--- a/Redfish Python/SetIdracDefaultSettingsREDFISH.py
+++ b/Redfish Python/SetIdracDefaultSettingsREDFISH.py
@@ -70,7 +70,7 @@ def set_idrac_default_settings():
     if statusCode == 200:
         print("\n- PASS, status code %s returned for POST command to reset iDRAC to default settings using reset type \"%s\"" % (statusCode, args["r"]))
     else:
-        print("\n- FAIL, status code %s returned, unable to reset iDRAC to default settings") % statusCode
+        print("\n- FAIL, status code %s returned, unable to reset iDRAC to default settings" % statusCode)
         sys.exit()
     time.sleep(15)
     print("\n- iDRAC will now reset to default settings and restart the iDRAC. iDRAC should be back up within a few minutes.")


### PR DESCRIPTION
Correct several instances of string interpolation being applied to the return value of a print statement rather than to the template string inside the print statement.  This throws an error when run under Python3.