### PR TITLE
packaging the python scripts: a proof of concept

### DIFF
--- a/Redfish Python/InsertEjectVirtualMediaREDFISH.py
+++ b/Redfish Python/InsertEjectVirtualMediaREDFISH.py
@@ -173,7 +173,7 @@ def eject_virtual_media():
         logging.info("\n- PASS, POST command passed to successfully eject virtual media, status code %s returned" % response.status_code)
 
 
-if __name__ == "__main__":
+def main():
     if args["script_examples"]:
         script_examples()
     if args["ip"] or args["ssl"] or args["u"] or args["p"] or args["x"]:
@@ -204,3 +204,6 @@ if __name__ == "__main__":
         eject_virtual_media()
     else:
         logging.error("\n- FAIL, invalid argument values or not all required parameters passed in. See help text or argument --script-examples for more details.")
+
+if __name__ == "__main__":
+    main()

--- a/Redfish Python/InsertEjectVirtualMediaREDFISH.py
+++ b/Redfish Python/InsertEjectVirtualMediaREDFISH.py
@@ -52,8 +52,8 @@ def script_examples():
     \n- InsertEjectVirtualMediaREDFISH.py -ip 192.168.0.120 -u root -p calvin --action insert --index 2 --uripath //192.168.0.130/cifs/VMware-700-A01.iso --username administrator --password P@ssword, this example shows attaching CD ISO image for virtual device index 2 (this example is only valid for iDRAC 6.00 or newer)
     \n- InsertEjectVirtualMediaREDFISH.py -ip 192.168.0.120 -u root -p calvin --action insert --uripath //192.168.0.130/cifs/VMware-700-A01.iso --username administrator --password P@ssword- --device cd, this example shows attaching CD ISO image (this example is only valid for iDRAC 5.10 or older).
     \n- InsertEjectVirtualMediaREDFISH.py -ip 192.168.0.120 -u root -p calvin --action insert --uripath //192.168.0.130/cifs/idsdm.img --username administrator --password P@ssword- --device removabledisk, this example shows attaching IMG image (this example is only valid for iDRAC 5.10 or older).
-    \n- InsertEjectVirtualMediaREDFISH.py -ip 192.168.0.120 -u root -p calvin --action eject --index 1, this example shows ejecting virtual media device index 1 (this example is only valid for iDRAC 6.00 or newer). 
-    \n- InsertEjectVirtualMediaREDFISH.py -ip 192.168.0.120 -u root -p calvin --action eject --device cd, this example shows ejecting virtual media CD ISO image (this example is only valid for iDRAC 5.10 or older). 
+    \n- InsertEjectVirtualMediaREDFISH.py -ip 192.168.0.120 -u root -p calvin --action eject --index 1, this example shows ejecting virtual media device index 1 (this example is only valid for iDRAC 6.00 or newer).
+    \n- InsertEjectVirtualMediaREDFISH.py -ip 192.168.0.120 -u root -p calvin --action eject --device cd, this example shows ejecting virtual media CD ISO image (this example is only valid for iDRAC 5.10 or older).
     """)
     sys.exit(0)
 
@@ -74,7 +74,7 @@ def get_iDRAC_version():
         iDRAC_version = "new"
     else:
         iDRAC_version = "old"
-            
+
 def get_virtual_media_info():
     if iDRAC_version == "new":
         if args["x"]:
@@ -97,7 +97,7 @@ def get_virtual_media_info():
     for i in data['Members']:
         pprint(i)
         print("\n")
-        
+
 def insert_virtual_media():
     if iDRAC_version == "old":
         if args["index"]:
@@ -172,7 +172,7 @@ def eject_virtual_media():
     else:
         logging.info("\n- PASS, POST command passed to successfully eject virtual media, status code %s returned" % response.status_code)
 
-    
+
 if __name__ == "__main__":
     if args["script_examples"]:
         script_examples()
@@ -204,9 +204,3 @@ if __name__ == "__main__":
         eject_virtual_media()
     else:
         logging.error("\n- FAIL, invalid argument values or not all required parameters passed in. See help text or argument --script-examples for more details.")
-    
-    
-        
-            
-        
-        

--- a/iDRAC Python Redfish Module/IdracRedfishSupport/cli/InsertEjectVirtualMediaREDFISH.py
+++ b/iDRAC Python Redfish Module/IdracRedfishSupport/cli/InsertEjectVirtualMediaREDFISH.py
@@ -174,6 +174,7 @@ def eject_virtual_media():
 
 
 def main():
+    global idrac_ip, idrac_username, idrac_password, verify_cert
     if args["script_examples"]:
         script_examples()
     if args["ip"] or args["ssl"] or args["u"] or args["p"] or args["x"]:

--- a/iDRAC Python Redfish Module/setup.py
+++ b/iDRAC Python Redfish Module/setup.py
@@ -20,8 +20,12 @@ setup(
         description=DESCRIPTION,
         long_description_content_type="text/markdown",
         long_description=long_description,
-        packages=["IdracRedfishSupport"],
+        packages=find_packages(),
         url='',
         install_requires=["requests"],
-        keywords=["python", "Redfish", "IDRAC"]
+        keywords=["python", "Redfish", "IDRAC"],
+        entry_points={
+            'console_scripts': [
+                "redfish-insert-eject-virtual-media = IdracRedfishSupport.cli.InsertEjectVirtualMediaREDFISH:main",
+        ]},
 )


### PR DESCRIPTION
as a proof of concept regarding issue #245, here's a change that would expose the script `InsertEjectVirtualMediaREDFISH.py` as a properly installed command that I arbitrarily chose to name `redfish-insert-eject-virtual-media` (the naming can be adapted of course)

the first commit is about cleaning up the .py script in terms of trailing spaces and extra empty lines at the end of the file; it brings no change at all, but makes the next move (introduce a `main()` function) less confusing

of course this would need to be applied on all the scripts, but it is something that can be relatively easily automated

let me know what you think of this approach


